### PR TITLE
chore: Update PikaOS URL to new homepage

### DIFF
--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -158,7 +158,7 @@ export const downloads: DownloadLink[] = [
     title: "PikaOS",
     statement:
       "A Debian-based gaming OS focused on ease of use and performance.",
-    url: "https://wiki.pika-os.com/en/home#downloads",
+    url: "https://pika-os.com/#editions",
     buttonText: "Download PikaOS",
   },
   {


### PR DESCRIPTION
PikaOS has a new website - this just updates the link to the new location