### PR TITLE
chore: add space between `a` and `unified`

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ import { downloads, members, partners } from "../data/site";
       <h1>Leveling Up the Ecosystem, <span>Together.</span></h1>
       <p class="lead-text">
         The <strong>Open Gaming Collective (OGC)</strong> is building a
-        <strong>unified</strong> set of gaming-focused components used across
+        <strong> unified</strong> set of gaming-focused components used across
         the Linux ecosystem.
       </p>
     </div>


### PR DESCRIPTION
normally whitespace is automatically added on linebreaks like this:

```
text bla
bla
```

which will make it render like:

`text bla bla`

however when an element is added no whitespace is added which made this not look as intended:

```
text bla
<strong>bla</strong>
```

will render as:
`text blabla`

an explicit whitespace in the element itself makes this explicit regardless of how the text is written.

---

Before:
<img width="879" height="251" alt="image" src="https://github.com/user-attachments/assets/a79f7130-d1ee-457d-9b99-bad92bec4fee" />

After:
<img width="879" height="251" alt="image" src="https://github.com/user-attachments/assets/595e5877-6213-4de6-9881-f6588f810a67" />

